### PR TITLE
v.0.1.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ CliveEdit gives your users a rich editing experience with a familiar toolbar whi
 - [v-model Bindings](#v-model-bindings)
 - [Exposed Methods](#exposed-methods)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Auto-Formatting Shortcuts](#auto-formatting-shortcuts)
 - [Toolbar](#toolbar)
   - [Default Toolbar Items](#default-toolbar-items)
   - [Custom Toolbar](#custom-toolbar)
@@ -129,6 +130,7 @@ The viewer renders markdown to styled HTML using the same theming system as the 
 | `disabled` | `boolean` | `false` | When `true`, disables all editing and toolbar actions. |
 | `toolbarItems` | `ToolbarItem[]` | *(built-in set)* | Override the default toolbar. See [Custom Toolbar](#custom-toolbar). |
 | `historyDepth` | `number` | `100` | Maximum number of undo/redo history entries. |
+| `stickyToolbar` | `boolean` | `true` | Keep the toolbar pinned at the top of the viewport when scrolling. Set to `false` to let it scroll with the content. |
 | `highlightOptions` | `{ theme?: string; langs?: string[] }` | `undefined` | Enable syntax highlighting in code blocks via [Shiki](https://shiki.matsu.io). See [Syntax Highlighting](#syntax-highlighting). |
 
 ---
@@ -226,6 +228,23 @@ These shortcuts work in both WYSIWYG and Markdown modes:
 | `Tab` (inside table) | Move to next cell |
 | `Shift+Tab` (inside table) | Move to previous cell |
 | `Enter` (inside table) | Move to same column in next row |
+
+---
+
+## Auto-Formatting Shortcuts
+
+In **WYSIWYG mode**, CliveEdit detects common markdown patterns as you type and automatically converts them into the corresponding rich-text elements. These shortcuts trigger when you press **Space** after typing the pattern at the very beginning of an empty line (inside a `<p>` or `<div>` block).
+
+| You type | Result |
+|---|---|
+| `* ` | Creates a bullet list (`<ul>`) |
+| `- ` | Creates a bullet list (`<ul>`) |
+| `1. ` (or any `N. `) | Creates an ordered list (`<ol>`) |
+| `# ` | Converts the line to a Heading 1 (`<h1>`) |
+| `## ` | Converts the line to a Heading 2 (`<h2>`) |
+| `### ` | Converts the line to a Heading 3 (`<h3>`) |
+
+> **Note:** Auto-formatting only applies when the shortcut characters are the *sole* content of the line. If the line already contains other text, the space is inserted normally. These shortcuts do not apply inside existing lists, blockquotes, tables, code blocks, or headings.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev_owl/cliveedit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CliveEdit — A themeable WYSIWYG markdown editor component for Vue 3",
   "type": "module",
   "main": "./dist/cliveedit.umd.js",
@@ -27,7 +27,8 @@
     "build": "vue-tsc --noEmit && vite build && vue-tsc -p tsconfig.build.json",
     "build:only": "vite build",
     "build:pages": "vite build --config vite.pages.config.ts",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
     "shiki": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev_owl/cliveedit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "CliveEdit — A themeable WYSIWYG markdown editor component for Vue 3",
   "type": "module",
   "main": "./dist/cliveedit.umd.js",

--- a/src/components/CliveEdit.vue
+++ b/src/components/CliveEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cliveedit ce-editor-wrap" :class="{ 'ce-disabled': disabled }" @keydown="onRootKeydown">
+  <div class="cliveedit ce-editor-wrap" :class="{ 'ce-disabled': disabled, 'ce-editor-wrap--sticky': stickyToolbar !== false }" @keydown="onRootKeydown">
     <!-- Toolbar -->
     <EditorToolbar
       :mode="currentMode"
@@ -65,6 +65,7 @@ const props = withDefaults(defineProps<CliveEditProps>(), {
   placeholder: 'Start writing...',
   disabled: false,
   historyDepth: 100,
+  stickyToolbar: true,
 })
 
 const emit = defineEmits<CliveEditEmits>()

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -15,6 +15,13 @@
   color: var(--ce-text);
 }
 
+/* When sticky toolbar is enabled, use overflow:clip instead of hidden.
+   clip still clips for border-radius but does NOT create a scroll container,
+   so position:sticky on the toolbar works relative to the viewport. */
+.ce-editor-wrap--sticky {
+  overflow: clip;
+}
+
 /* ---- WYSIWYG area ---- */
 .ce-wysiwyg-wrap {
   position: relative;

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -14,6 +14,13 @@
   user-select: none;
 }
 
+/* Sticky toolbar — pinned to the viewport top while scrolling */
+.ce-editor-wrap--sticky .ce-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
 /* ---- Separator between groups ---- */
 .ce-toolbar__divider {
   width: 1px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,12 @@ export interface CliveEditProps {
   /** Maximum number of undo history entries (default 100) */
   historyDepth?: number
   /**
+   * Keep the toolbar pinned at the top of the viewport when scrolling.
+   * Enabled by default to support long documents.
+   * Set to `false` to let the toolbar scroll with the content.
+   */
+  stickyToolbar?: boolean
+  /**
    * Enable syntax highlighting in code blocks via Shiki.
    * Requires `shiki` to be installed as a peer dependency.
    * Pass `{}` to use defaults (github-light theme, common languages).


### PR DESCRIPTION
This pull request introduces a new auto-formatting feature for WYSIWYG mode and adds support for a sticky toolbar in the CliveEdit editor. The changes improve the editing experience by automatically converting markdown shortcuts into rich-text elements and enhance usability for long documents by keeping the toolbar visible while scrolling. Documentation and styles have been updated to reflect these features, and minor improvements were made to list creation behavior.

**Auto-formatting shortcuts in WYSIWYG mode:**

* Added logic in `WysiwygEditor.vue` to detect markdown patterns (`* `, `- `, `1. `, `# `, `## `, `### `) at the start of a line and automatically convert them to lists or headings when the space key is pressed.
* Updated `README.md` with a new section describing auto-formatting shortcuts, including usage notes and examples.

**Sticky toolbar feature:**

* Introduced the `stickyToolbar` prop to `CliveEdit.vue` and `CliveEditProps`, defaulting to `true`, which keeps the toolbar pinned at the top of the viewport when scrolling. [[1]](diffhunk://#diff-6feedb013e11d656a90be6a0a06c38a89f8cea696cbab89dce5f570e65690cc8R68) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R72-R77)
* Modified editor and toolbar styles to implement sticky positioning and proper overflow behavior when `stickyToolbar` is enabled. [[1]](diffhunk://#diff-0c3c38e3878318bc315cf3076839d51b3452bdbdbf2001d7af0bd6bc8195f615R18-R24) [[2]](diffhunk://#diff-f03aa7de25247074ec90497b47aea6b8c840fbb3354294246db3787007980e50R17-R23)
* Updated `README.md` to document the `stickyToolbar` prop and its usage.

**List creation improvements:**

* Improved list creation in `useEditor.ts` so that when no text is selected, the new list item is pre-selected for immediate editing, and empty wrappers are cleaned up.
* Fixed edge cases in list insertion logic to ensure proper block structure.

**Documentation and build updates:**

* Added new sections and links in `README.md` for auto-formatting and sticky toolbar.
* Updated `package.json` version to 0.1.8 and added a `prepublishOnly` script to ensure builds before publishing. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R31)